### PR TITLE
Fix application.launchorfocus for apps with spaces

### DIFF
--- a/Hydra/application.lua
+++ b/Hydra/application.lua
@@ -5,5 +5,5 @@ end
 
 doc.application.launchorfocus = {"application.launchorfocus(name)", "Launches the app with the given name, or activates it if it's already running."}
 function application.launchorfocus(name)
-  os.execute("open -a " .. name)
+  os.execute("open -a \"" .. name .. "\"")
 end


### PR DESCRIPTION
Currently applications with spaces in their names are not launched correctly with `application.launchorfocus`.  E.g. `application.launchorfocus("Google Chrome")` does nothing.  This is because the application name is not quoted in the call to `open`.

This PR quotes the application name so `open` interprets the command correctly.
