### PR TITLE
Make the module list scrollable

### DIFF
--- a/docgen/styles.css
+++ b/docgen/styles.css
@@ -23,6 +23,7 @@ body {
     width: 200px;
     height: 100%;
     background-color: #1570A6;
+    overflow-y: scroll;
 }
 
 #modules ul {


### PR DESCRIPTION
On smaller screens, the module list y-overflow is hidden.
