### PR TITLE
put quotes around resourcesdir - because cask uses spaces in the path. F...

### DIFF
--- a/Hydra/fallback_init.lua
+++ b/Hydra/fallback_init.lua
@@ -1,7 +1,7 @@
 local fallbackinit = {}
 
 function fallbackinit.open_sample_config()
-  os.execute("open " .. hydra.resourcesdir .. "/sample_config.lua")
+  os.execute("open \"" .. hydra.resourcesdir .. "/sample_config.lua\"")
 end
 
 function fallbackinit.run()


### PR DESCRIPTION
...ixes #130
