### PR TITLE
Fix geometry.rectmidpoint() mathematical error.

### DIFF
--- a/Hydra/geometry.lua
+++ b/Hydra/geometry.lua
@@ -13,7 +13,7 @@ doc.geometry.rectmidpoint = {"geometry.rectmidpoint(r) -> point", "Returns the m
 function geometry.rectmidpoint(r)
   return {
     x = r.x + r.w * 0.5,
-    y = r.y + r.h * 0.5,
+    y = -r.y + r.h * 0.5,
   }
 end
 


### PR DESCRIPTION
With a rect 

```
{
   h = 1058,
   w = 1920,
   x = 0,
   y = 1080
}
```

You'd expect `geometry.rectmidpoint()` to return:

```
{
  x =  960,
  y = -551
}
```

However, it returned:

```
{
   x = 960,
   y = 1609
}
```

This fixes that issue. 
