### PR TITLE
Switch to building .zips.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ DerivedData
 
 /Hydra.app
 /Hydra-*.app.tar.gz
+/Hydra-*.app.zip

--- a/release.sh
+++ b/release.sh
@@ -4,10 +4,10 @@ set -e
 
 # build app
 xcodebuild clean build
-VERSION=$(defaults read $(pwd)/Hydra/Hydra-Info CFBundleVersion)
-FILENAME="Hydra-$VERSION.app.tar.gz"
+VERSION=$(defaults read "$(pwd)/Hydra/Hydra-Info" CFBundleVersion)
+FILENAME="Hydra-$VERSION.app.zip"
 
 # build .zip
-rm -rf $FILENAME
-tar -zcf $FILENAME -C build/Release Hydra.app
+rm -rf "$FILENAME"
+zip "$FILENAME" build/Release/Hydra.app
 echo "Created $FILENAME"


### PR DESCRIPTION
Switches from tarballs to zips and increases safety of the release.sh
script.
