### PR TITLE
Fix error thrown when pressing down in repo too many times

### DIFF
--- a/Hydra/repl.lua
+++ b/Hydra/repl.lua
@@ -103,6 +103,10 @@ function Stdin:usecurrenthistory()
   else
     partialcmd = self.cmds[self.cmdpos]
   end
+  
+  if partialcmd == nil then
+    return
+  end
 
   self.chars = {}
   for i = 1, partialcmd:len() do


### PR DESCRIPTION
Fixes a little annoying bug. When you have the REPL open and hit down when you've reached the end of your history, a lua error gets thrown:

![image](https://cloud.githubusercontent.com/assets/5489149/3491132/d37c4314-0586-11e4-9560-f3acada81ffb.png)
