### PR TITLE
Fix documentation of textgrid:resize

### DIFF
--- a/Hydra/textgrid.m
+++ b/Hydra/textgrid.m
@@ -119,7 +119,7 @@ static int textgrid_setfg(lua_State *L) {
 
 static hydradoc doc_textgrid_resize = {
     "textgrid", "resize", "textgrid:resize(size)",
-    "Resizes the textgrid to the number of rows and columns given in the size-table with keys {x,y}."
+    "Resizes the textgrid to the number of rows and columns given in the size-table with keys {w,h}."
 };
 
 static int textgrid_resize(lua_State *L) {


### PR DESCRIPTION
textgrid:resize expects a size table with w and h keys, not x and y as the documentation says.
