### PR TITLE
Properly index fnutils.{sequence,partial}

### DIFF
--- a/Hydra/API/fnutils.lua
+++ b/Hydra/API/fnutils.lua
@@ -109,7 +109,7 @@ end
 
 --- fnutils.sequence(...) -> fn
 --- Returns a list of the results of the passed functions.
-function sequence(...)
+function fnutils.sequence(...)
   local arg = table.pack(...)
   return function()
     local results = {}
@@ -122,7 +122,7 @@ end
 
 --- fnutils.partial(fn, ...) -> fn'
 --- Returns fn partially applied to arg (...).
-function partial(fn, ...)
+function fnutils.partial(fn, ...)
   local args = table.pack(...)
   return function(...)
     for idx, val in ipairs(table.pack(...)) do


### PR DESCRIPTION
Self explanatory. These functions aren't referenced anywhere in the core... but will probably break someone's config if they're using them bare.
