### PR TITLE
battery and battery.watcher API

### DIFF
--- a/Hydra.xcodeproj/project.pbxproj
+++ b/Hydra.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		04FBC8221976C37000B33BE3 /* audiodevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 04FBC8211976C37000B33BE3 /* audiodevice.m */; };
 		2303FBED196A410D00D2EFDE /* brightness.m in Sources */ = {isa = PBXBuildFile; fileRef = 2303FBEC196A410D00D2EFDE /* brightness.m */; };
+		2316BA4A197B28B900EEE33F /* battery.m in Sources */ = {isa = PBXBuildFile; fileRef = 2316BA49197B28B900EEE33F /* battery.m */; };
+		2316BA4C197B5E9D00EEE33F /* battery_watcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 2316BA4B197B5E9D00EEE33F /* battery_watcher.m */; };
 		9400269519514372000D15C1 /* geometry.lua in Resources */ = {isa = PBXBuildFile; fileRef = 9400269419514372000D15C1 /* geometry.lua */; };
 		940026971951437A000D15C1 /* geometry.m in Sources */ = {isa = PBXBuildFile; fileRef = 940026961951437A000D15C1 /* geometry.m */; };
 		94022D691976DEAF00BF7CB3 /* hydra_dockicon.m in Sources */ = {isa = PBXBuildFile; fileRef = 94022D681976DEAF00BF7CB3 /* hydra_dockicon.m */; };
@@ -149,6 +151,8 @@
 /* Begin PBXFileReference section */
 		04FBC8211976C37000B33BE3 /* audiodevice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = audiodevice.m; sourceTree = "<group>"; };
 		2303FBEC196A410D00D2EFDE /* brightness.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = brightness.m; sourceTree = "<group>"; };
+		2316BA49197B28B900EEE33F /* battery.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = battery.m; sourceTree = "<group>"; };
+		2316BA4B197B5E9D00EEE33F /* battery_watcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = battery_watcher.m; sourceTree = "<group>"; };
 		9400269419514372000D15C1 /* geometry.lua */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = geometry.lua; sourceTree = "<group>"; };
 		940026961951437A000D15C1 /* geometry.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = geometry.m; sourceTree = "<group>"; };
 		94022D681976DEAF00BF7CB3 /* hydra_dockicon.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = hydra_dockicon.m; sourceTree = "<group>"; };
@@ -492,6 +496,8 @@
 				94A1537B194D77A400F29F8F /* window.lua */,
 				94BDB49B19094B7A00BD0553 /* application.m */,
 				04FBC8211976C37000B33BE3 /* audiodevice.m */,
+				2316BA49197B28B900EEE33F /* battery.m */,
+				2316BA4B197B5E9D00EEE33F /* battery_watcher.m */,
 				2303FBEC196A410D00D2EFDE /* brightness.m */,
 				94FF83D51970DAD4005B47D7 /* eventtap.m */,
 				940026961951437A000D15C1 /* geometry.m */,
@@ -681,6 +687,7 @@
 				9445CA81190833C1002568BB /* lbitlib.c in Sources */,
 				9445CA8B190833C1002568BB /* linit.c in Sources */,
 				9445CA9E190833C1002568BB /* lvm.c in Sources */,
+				2316BA4C197B5E9D00EEE33F /* battery_watcher.m in Sources */,
 				9445CA8F190833C1002568BB /* lmem.c in Sources */,
 				94276CA71958809C003BF95B /* helpers.m in Sources */,
 				9445CA88190833C1002568BB /* ldump.c in Sources */,
@@ -690,6 +697,7 @@
 				94DE5949194F1A31004D242E /* hydra.m in Sources */,
 				9445CA96190833C1002568BB /* lstring.c in Sources */,
 				9445CA7E190833C1002568BB /* lapi.c in Sources */,
+				2316BA4A197B28B900EEE33F /* battery.m in Sources */,
 				9445CA9F190833C1002568BB /* lzio.c in Sources */,
 				94C36940194DD94700EE3A2D /* hydra_updates.m in Sources */,
 				04FBC8221976C37000B33BE3 /* audiodevice.m in Sources */,

--- a/Hydra/API/battery.m
+++ b/Hydra/API/battery.m
@@ -1,0 +1,258 @@
+#import "helpers.h"
+#import <IOKit/ps/IOPowerSources.h>
+#import <IOKit/ps/IOPSKeys.h>
+#import <IOKit/pwr_mgt/IOPM.h>
+#import <IOKit/pwr_mgt/IOPMLib.h>
+
+/// === battery ===
+/// Functions for getting battery info. All functions here may return nil, if the information requested is not available.
+
+// Gets battery info from IOPM API.
+NSDictionary* get_iopm_battery_info() {
+    mach_port_t masterPort;
+    CFArrayRef batteryInfo;
+    
+    if (kIOReturnSuccess == IOMasterPort(MACH_PORT_NULL, &masterPort) &&
+        kIOReturnSuccess == IOPMCopyBatteryInfo(masterPort, &batteryInfo) &&
+        CFArrayGetCount(batteryInfo))
+    {
+        CFDictionaryRef battery = CFDictionaryCreateCopy(NULL, CFArrayGetValueAtIndex(batteryInfo, 0));
+        CFRelease(batteryInfo);
+        return (__bridge_transfer NSDictionary*) battery;
+    }
+    return NULL;
+}
+
+// Get battery info from IOPS API.
+NSDictionary* get_iops_battery_info() {
+    CFTypeRef info = IOPSCopyPowerSourcesInfo();
+    
+    if (info == NULL)
+        return NULL;
+    
+    
+    CFArrayRef list = IOPSCopyPowerSourcesList(info);
+    
+    // Nothing we care about here...
+    if (list == NULL || !CFArrayGetCount(list)) {
+        if (list)
+            CFRelease(list);
+        
+        CFRelease(info);
+        return NULL;
+    }
+    
+    CFDictionaryRef battery = CFDictionaryCreateCopy(NULL, IOPSGetPowerSourceDescription(info, CFArrayGetValueAtIndex(list, 0)));
+    
+    // Battery is released by ARC transfer.
+    CFRelease(list);
+    CFRelease(info);
+    
+    return (__bridge_transfer NSDictionary* ) battery;
+}
+
+// Get battery info from IOPMPS Apple Smart Battery API.
+NSDictionary* get_iopmps_battery_info() {
+    io_registry_entry_t entry = 0;
+    entry = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceNameMatching("AppleSmartBattery"));
+    if (entry == IO_OBJECT_NULL)
+        return nil;
+    
+    CFMutableDictionaryRef battery;
+    IORegistryEntryCreateCFProperties(entry, &battery, NULL, 0);
+    return (__bridge_transfer NSDictionary *) battery;
+}
+
+// Helper function to yank a number from a dictionary by key, and push it onto the LUA stack.
+static int _get_number_value_or_nil(lua_State* L, NSDictionary* dict, NSString* key) {
+    NSNumber* value = [dict objectForKey:key];
+    if (value == nil)
+        lua_pushnil(L);
+    else
+        lua_pushnumber(L, [value doubleValue]);
+    
+    return 1;
+}
+
+// Helper function to yank a bool from a dictionary by key, and push it onto the LUA stack.
+static int _get_boolean_value_or_nil(lua_State* L, NSDictionary* dict, NSString* key) {
+    NSNumber* value = [dict objectForKey:key];
+    if (value == nil)
+        lua_pushnil(L);
+    else
+        lua_pushboolean(L, [value boolValue]);
+    
+    return 1;
+}
+
+
+// Helper function to yank a string from a dictionary by key and push it onto the LUA stack.
+static int _get_string_value_or_nil(lua_State* L, NSDictionary* dict, NSString* key) {
+    NSString* value = [dict objectForKey:key];
+    if (value == nil)
+        lua_pushnil(L);
+    else
+        lua_pushstring(L, [value UTF8String]);
+    
+    return 1;
+}
+
+/// battery.cycles() -> number
+/// Returns the number of cycles the connected battery has went through.
+static int battery_cycles(lua_State *L) {
+    return _get_number_value_or_nil(L, get_iopm_battery_info(), @kIOBatteryCycleCountKey);
+}
+
+/// battery.name() -> number
+/// Returns the name of the battery.
+static int battery_name(lua_State *L) {
+    return _get_string_value_or_nil(L, get_iops_battery_info(), @kIOPSNameKey);
+}
+
+/// battery.maxcapacity() -> number
+/// Returns the current maximum capacity of the battery in mAh.
+static int battery_maxcapacity(lua_State *L) {
+    return _get_number_value_or_nil(L, get_iopm_battery_info(), @kIOBatteryCapacityKey);
+}
+
+/// battery.capacity() -> number
+/// Returns the current capacity of the battery in mAh.
+static int battery_capacity(lua_State *L) {
+    return _get_number_value_or_nil(L, get_iopm_battery_info(), @kIOBatteryCurrentChargeKey);
+}
+
+/// battery.designcapacity() -> number
+/// Returns the design capacity of the battery in mAh.
+static int battery_designcapacity(lua_State *L) {
+    return _get_number_value_or_nil(L, get_iopmps_battery_info(), @kIOPMPSDesignCapacityKey);
+}
+
+/// battery.voltage() -> number
+/// Returns the voltage flow of the battery in mV.
+static int battery_voltage(lua_State *L) {
+    return _get_number_value_or_nil(L, get_iopm_battery_info(), @kIOBatteryVoltageKey);
+}
+
+/// battery.amperage() -> number
+/// Returns the amperage of the battery in mA. (will be negative if battery is discharging)
+static int battery_amperage(lua_State *L) {
+    return _get_number_value_or_nil(L, get_iopm_battery_info(), @kIOBatteryAmperageKey);
+}
+
+/// battery.watts() -> number
+/// Returns the watts into or out of the battery in Watt (will be negative if battery is discharging)
+static int battery_watts(lua_State *L) {
+    NSDictionary* battery = get_iopm_battery_info();
+    
+    NSNumber *amperage = [battery objectForKey:@kIOBatteryVoltageKey];
+    NSNumber *voltage = [battery objectForKey:@kIOBatteryAmperageKey];
+    
+    if (amperage && voltage) {
+        double battery_wattage = ([amperage doubleValue] * [voltage doubleValue]) / 1000000;
+        lua_pushnumber(L, battery_wattage);
+    } else
+        lua_pushnil(L);
+    
+    return 1;
+}
+
+/// battery.health() -> string
+/// Returns the health status of the battery. One of {Good, Fair, Poor}
+static int battery_health(lua_State *L) {
+    return _get_string_value_or_nil(L, get_iops_battery_info(), @kIOPSBatteryHealthKey);
+}
+
+/// battery.healthcondition() -> string
+/// Returns the health condition status of the battery. One of {Check Battery, Permanent Battery Failure}. Nil if there is no health condition set.
+static int battery_healthcondition(lua_State *L) {
+    return _get_string_value_or_nil(L, get_iops_battery_info(), @kIOPSBatteryHealthConditionKey);
+}
+
+/// battery.percentage() -> number
+/// Returns the current percentage of the battery between 0 and 100.
+static int battery_percentage(lua_State *L) {
+    NSDictionary* battery = get_iops_battery_info();
+    
+    // IOPS Gives the proper percentage reading, that the OS displays...
+    // IOPM... oddly enough... is a few percentage points off.
+    NSNumber *maxCapacity = [battery objectForKey:@kIOPSMaxCapacityKey];
+    NSNumber *currentCapacity = [battery objectForKey:@kIOPSCurrentCapacityKey];
+    
+    if (maxCapacity && currentCapacity) {
+        double battery_percentage = ([currentCapacity doubleValue] / [maxCapacity doubleValue]) * 100;
+        lua_pushnumber(L, battery_percentage);
+    } else
+        lua_pushnil(L);
+        
+    return 1;
+}
+
+/// battery.timeremaining() -> number
+/// Returns the time remaining in minutes. Or a negative value: -1 = calculating time remaining, -2 = unlimited (i.e. you're charging, or apple has somehow discovered an infinite power source.)
+
+static int battery_timeremaining(lua_State* L) {
+    CFTimeInterval remaining = IOPSGetTimeRemainingEstimate();
+    
+    if (remaining > 0)
+        remaining /= 60;
+    
+    lua_pushnumber(L, remaining);
+    return 1;
+}
+
+/// battery.timetofullcharge() -> number
+/// Returns the time remaining to a full charge in minutes. Or a negative value, -1 = calculating time remaining.
+static int battery_timetofullcharge(lua_State* L) {
+    return _get_number_value_or_nil(L, get_iops_battery_info(), @kIOPSTimeToFullChargeKey);
+}
+
+/// battery.ischarging() -> boolean
+/// Returns true if the battery is charging.
+static int battery_ischarging(lua_State* L) {
+    return _get_boolean_value_or_nil(L, get_iops_battery_info(), @kIOPSIsChargingKey);
+}
+
+/// battery.ischarged() -> boolean
+/// Returns true if battery is charged.
+static int battery_ischarged(lua_State* L) {
+    return _get_boolean_value_or_nil(L, get_iops_battery_info(), @kIOPSIsChargedKey);
+}
+
+/// battery.isfinishingcharge() -> boolean
+/// Returns true if battery is finishing charge.
+static int battery_isfinishingcharge(lua_State* L) {
+    return _get_boolean_value_or_nil(L, get_iops_battery_info(), @kIOPSIsFinishingChargeKey);
+}
+
+static luaL_Reg batterylib[] = {
+    {"cycles", battery_cycles},
+    {"name", battery_name},
+    
+    {"maxcapacity", battery_maxcapacity},
+    {"capacity", battery_capacity},
+    {"designcapacity", battery_designcapacity},
+    {"percentage", battery_percentage},
+    
+    {"voltage", battery_voltage},
+    {"amperage", battery_amperage},
+    {"watts", battery_watts},
+    
+    {"health", battery_health},
+    {"healthcondition", battery_healthcondition},
+    
+    {"timeremaining", battery_timeremaining},
+    {"timetofullcharge", battery_timetofullcharge},
+    
+    
+    {"ischarging", battery_ischarging},
+    {"ischarged", battery_ischarged},
+    {"isfinishingcharge", battery_isfinishingcharge},
+    
+    {NULL, NULL}
+};
+
+int luaopen_battery(lua_State* L) {
+    luaL_newlib(L, batterylib);
+    
+    return 1;
+}

--- a/Hydra/API/battery_watcher.m
+++ b/Hydra/API/battery_watcher.m
@@ -1,0 +1,120 @@
+#import "helpers.h"
+#import <IOKit/ps/IOPowerSources.h>
+#import <IOKit/ps/IOPSKeys.h>
+
+/// === battery.watcher ===
+/// Functions for watching battery state changes.
+
+typedef struct _battery_watcher_t {
+    lua_State* L;
+    CFRunLoopSourceRef t;
+    int fn;
+    int self;
+    bool started;
+} battery_watcher_t;
+
+static void callback(void *info) {
+    battery_watcher_t* t = info;
+    lua_State* L = t->L;
+    lua_rawgeti(L, LUA_REGISTRYINDEX, t->fn);
+    if (lua_pcall(L, 0, 0, 0))
+        hydra_handle_error(L);
+    
+}
+
+/// battery.watcher(fn) -> battery.watcher
+/// Creates a battery watcher that can be started. When started, fn will be called each time a battery attribute changes.
+static int battery_watcher_new(lua_State* L) {
+    // Since we're calling this function via __call, we pop the "self" table.
+    lua_remove(L, 1);
+    
+    luaL_checktype(L, 1, LUA_TFUNCTION);
+    
+    battery_watcher_t* watcher = lua_newuserdata(L, sizeof(battery_watcher_t));
+    watcher->L = L;
+    
+    lua_pushvalue(L, 1);
+    watcher->fn = luaL_ref(L, LUA_REGISTRYINDEX);
+    
+    luaL_getmetatable(L, "battery_watcher");
+    lua_setmetatable(L, -2);
+    
+    watcher->t = IOPSNotificationCreateRunLoopSource(callback, watcher);
+    watcher->started = false;
+    return 1;
+}
+
+/// battery.watcher:start() -> self
+/// Starts the battery watcher, making it so fn is called each time a battery attribute changes.
+static int battery_watcher_start(lua_State* L) {
+    battery_watcher_t* watcher = luaL_checkudata(L, 1, "battery_watcher");
+    
+    lua_settop(L, 1);
+    
+    if (watcher->started) return 1;
+    
+    watcher->started = YES;
+    
+    watcher->self = hydra_store_handler(L, 1);
+    CFRunLoopAddSource(CFRunLoopGetMain(), watcher->t, kCFRunLoopCommonModes);
+    return 1;
+}
+
+/// battery.watcher:stop() -> self
+/// Stops the battery watcher's fn from getting called until started again.
+static int battery_watcher_stop(lua_State* L) {
+    battery_watcher_t* watcher = luaL_checkudata(L, 1, "battery_watcher");
+    lua_settop(L, 1);
+    
+    if (!watcher->started) return 1;
+    watcher->started = NO;
+    
+    hydra_remove_handler(L, watcher->self);
+    CFRunLoopRemoveSource(CFRunLoopGetMain(), watcher->t, kCFRunLoopCommonModes);
+    return 1;
+}
+
+/// battery.watcher.stopall()
+/// Stops all running battery watchers; called automatically when user config reloads.
+static int battery_watcher_stopall(lua_State* L) {
+    lua_getglobal(L, "battery");
+    lua_getfield(L, -1, "watcher");
+    lua_getfield(L, -1, "stop");
+    hydra_remove_all_handlers(L, "battery_watcher");
+    return 0;
+}
+
+static int battery_watcher_gc(lua_State* L) {
+    battery_watcher_t* watcher = luaL_checkudata(L, 1, "battery_watcher");
+    
+    luaL_unref(L, LUA_REGISTRYINDEX, watcher->fn);
+    CFRunLoopSourceInvalidate(watcher->t);
+    CFRelease(watcher->t);
+    return 0;
+}
+
+static luaL_Reg battery_watcherlib[] = {
+    {"stop", battery_watcher_stop},
+    {"stopall", battery_watcher_stopall},
+    {"start", battery_watcher_start},
+    {"__gc", battery_watcher_gc}
+};
+
+int luaopen_battery_watcher(lua_State* L) {
+    luaL_newlib(L, battery_watcherlib);
+    
+    lua_pushvalue(L, -1);
+    lua_setfield(L, -2, "__index");
+    
+    lua_pushvalue(L, -1);
+    lua_setfield(L, LUA_REGISTRYINDEX, "battery_watcher");
+    
+    if (luaL_newmetatable(L, "battery_watcher__mt")) {
+        lua_pushcfunction(L, battery_watcher_new);
+        lua_setfield(L, -2, "__call");
+    }
+    
+    lua_setmetatable(L, -2);
+    
+    return 1;
+}

--- a/Hydra/API/hydra.lua
+++ b/Hydra/API/hydra.lua
@@ -12,6 +12,7 @@ local function clear_old_state()
   textgrid.destroyall()
   notify.unregisterall()
   notify.applistener.stopall()
+  battery.watcher.stopall()
 end
 
 local function load_default_config()

--- a/Hydra/API/timer.m
+++ b/Hydra/API/timer.m
@@ -12,7 +12,7 @@ typedef struct _timer_t {
     BOOL started;
 } timer_t;
 
-void callback(CFRunLoopTimerRef timer, void *info) {
+static void callback(CFRunLoopTimerRef timer, void *info) {
     timer_t* t = info;
     lua_State* L = t->L;
     lua_rawgeti(L, LUA_REGISTRYINDEX, t->fn);

--- a/Hydra/Bootstrapping/main.m
+++ b/Hydra/Bootstrapping/main.m
@@ -9,6 +9,9 @@ int main(int argc, const char * argv[]) {
 int luaopen_application(lua_State* L);
 int luaopen_audiodevice(lua_State* L);
 int luaopen_brightness(lua_State* L);
+int luaopen_battery(lua_State* L);
+int luaopen_battery_watcher(lua_State* L);
+
 //int luaopen_eventtap(lua_State* L);
 int luaopen_geometry(lua_State* L);
 int luaopen_hotkey(lua_State* L);
@@ -46,6 +49,8 @@ typedef struct _hydralib {
 static const hydralib hydralibs[] = {
     {"application",  NULL,          luaopen_application},
     {"audiodevice",  NULL,          luaopen_audiodevice},
+    {"battery",      NULL,          luaopen_battery},
+    {"battery",      "watcher",     luaopen_battery_watcher},
     {"brightness",   NULL,          luaopen_brightness},
 //    {"eventtap",     NULL,          luaopen_eventtap},
     {"geometry",     NULL,          luaopen_geometry},


### PR DESCRIPTION
Per #261, a battery API has been introduced.

Documentation as follows: 
## battery

Functions for getting battery info. All functions here may return nil, if the information requested is not available.

``` lua
battery.cycles() -> number -- Returns the number of cycles the connected battery has went through.
battery.name() -> number -- Returns the name of the battery.
battery.maxcapacity() -> number -- Returns the current maximum capacity of the battery in mAh.
battery.capacity() -> number -- Returns the current capacity of the battery in mAh.
battery.designcapacity() -> number -- Returns the design capacity of the battery in mAh.
battery.voltage() -> number -- Returns the voltage flow of the battery in mV.
battery.amperage() -> number -- Returns the amperage of the battery in mA. (will be negative if battery is discharging)
battery.watts() -> number -- Returns the watts into or out of the battery in Watt (will be negative if battery is discharging)
battery.health() -> string -- Returns the health status of the battery. One of {Good, Fair, Poor}
battery.healthcondition() -> string -- Returns the health condition status of the battery. One of {Check Battery, Permanent Battery Failure}. Nil if there is no health condition set.
battery.percentage() -> number -- Returns the current percentage of the battery between 0 and 100.
battery.timeremaining() -> number -- Returns the time remaining in minutes. Or a negative value: -1 = calculating time remaining, -2 = unlimited (i.e. you're charging, or apple has somehow discovered an infinite power source.)
battery.timetofullcharge() -> number -- Returns the time remaining to a full charge in minutes. Or a negative value, -1 = calculating time remaining.
battery.ischarging() -> boolean -- Returns true if the battery is charging.
battery.ischarged() -> boolean -- Returns true if battery is charged.
battery.isfinishingcharge() -> boolean -- Returns true if battery is finishing charge.
```
## battery.watcher

Functions for watching battery state changes.

``` lua
battery.watcher(fn) -> battery.watcher -- Creates a battery watcher that can be started. When started, fn will be called each time a battery attribute changes.
battery.watcher:start() -> self - Starts the battery watcher, making it so fn is called each time a battery attribute changes.
battery.watcher:stop() -> self -- Stops the battery watcher's fn from getting called until started again.
battery.watcher.stopall() -- Stops all running battery watchers; called automatically when user config reloads.
```
