### PR TITLE
Make sure homebrew has the latest version of lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ built-in `mjolnir` module, and all Lua modules that you have installed
 2. Install Lua 5.2 into /usr/local e.g. from [Homebrew](http://brew.sh/), and then install LuaRocks for Lua 5.2:
 
    ~~~bash
+   $ brew update
    $ brew install lua
    $ brew install luarocks
    $ echo 'rocks_servers = { "http://rocks.moonscript.org" }' > ~/.luarocks/config.lua


### PR DESCRIPTION
Almost gave up on this because it would up installing lua 5.1.5, and then luarocks would not install anything. Being someone who knows nothing about lua, this was almost enough for me to be like "well, ping me again when you get it working". So, just adding to the instructions to udate lua so that we have the latest packages.

After installing, it tells me it doesn't work unless I run `brew sh`, but I can't install the gems from my shell or the brew shell.
![screenshot 2014-09-20 17 56 55](https://cloud.githubusercontent.com/assets/77495/4346947/0836af5e-4123-11e4-860f-6aa109f67349.png)

Trying to make the dirs and add the settings, still can't install any modules.
![screenshot 2014-09-20 17 57 10](https://cloud.githubusercontent.com/assets/77495/4346950/139c0236-4123-11e4-9d0d-9705fa1c5e73.png)

Can't find or list any luarocks modules.
![screenshot 2014-09-20 17 59 24](https://cloud.githubusercontent.com/assets/77495/4346951/1a186abe-4123-11e4-8b8c-e768d89eff59.png)

The solution: Update homebrew, and then upgrade lua and luarocks. But, if I had the most up-to-date version of homebrew in the first place, this wouldn't have happened.
