### PR TITLE
put module list into index for docset

### DIFF
--- a/docs/templates/index.html.erb
+++ b/docs/templates/index.html.erb
@@ -14,5 +14,15 @@
     <section>
       <%= content %>
     </section>
+    <section>
+    <!-- tables suck., I know, but it's fast to code -->
+    <table><tr><td valign="top">Documented modules</td><td valign="top">
+      <ul>
+        <% docmods.each do |mod| %>
+          <li><a href="<%= mod['name'] %>.html"><%= mod['name'] %></a></li>
+        <% end %>
+      </ul>
+    </td></tr></table>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
makes the index more usable and allows for easy moving of generated html to be used as a local html source of docs for those who don't want to use dash.
