### PR TITLE
README.md: remove that no app can implement spaces support

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ principles:
 
    Not a question. But anyway, there are no public *or* private APIs
    to manage Spaces in OS X 10.9 or 10.10, there are only private APIs
-   that work in 10.8. So, literally no app can do this, not just us.
+   that work in 10.8. So, it's a hard limitation to overcome.
 
 2. **Does LuaRocks have a way to upgrade modules automatically?**
 


### PR DESCRIPTION
Regardless of how they do it (I do not know, and it’s a closed-source app), [SizeUp](http://www.irradiatedsoftware.com/sizeup/) supports moving apps between spaces, and does so without a hitch; it works well and consistently.

Maybe they’re using some hacky way to do it, but either way it isn’t true that no app can do it.