### PR TITLE
Add ability to set bindings as keycodes

### DIFF
--- a/mods/hotkey/hotkey.lua
+++ b/mods/hotkey/hotkey.lua
@@ -27,7 +27,13 @@ local function wrap(fn)
 end
 
 function hotkey.new(mods, key, pressedfn, releasedfn)
-  local keycode = keycodes.map[key:lower()]
+  local keycode
+
+  if (key:sub(1, 1) == '#') then
+    keycode = tonumber(key:sub(2))
+  else
+    keycode = keycodes.map[key:lower()]
+  end
 
   local _pressedfn = wrap(pressedfn)
   local _releasedfn = wrap(releasedfn)


### PR DESCRIPTION
This helps overcome issue which appears when config contains
binding for key symbol which is absent from active keyboard layout so config load fails.

To check out real keycodes next commands in mjolnir console may be
used:
local keycodes = require "mjolnir.keycodes.internal"
for k,v in pairs (keycodes.map) do print(k, v) end